### PR TITLE
Fix phpBB error when quoting some posts

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -185,7 +185,7 @@ class main_listener implements EventSubscriberInterface
 				/* Replace INLINE images in the same place where they were placed */
 				if (!empty($rows))
 				{
-					$preg = '/<ATTACHMENT filename="[^"]*?" index="(' . implode('|', array_keys($rows)) . ')">.*?<\/ATTACHMENT>/';
+					$preg = '#<ATTACHMENT filename="[^"]*?" index="(' . implode('|', array_keys($rows)) . ')">.*?</ATTACHMENT>#';
 
 					$text = preg_replace_callback(
 						$preg,
@@ -197,7 +197,7 @@ class main_listener implements EventSubscriberInterface
 
 							unset($rows[$id]);
 
-							return "[url={$link}&mode=view]{$img['open']}{$link}{$img['close']}[/url]";
+							return "[url={$link}&amp;mode=view]{$img['open']}{$link}{$img['close']}[/url]";
 						},
 						$text
 					);

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -210,7 +210,7 @@ class main_listener implements EventSubscriberInterface
 						/* Use relative path for the sake of future's proof */
 						$link = $this->root_path . 'download/file.' . $this->php_ext . '?id=' . (int) $row['attach_id'];
 
-						$text .= "\n[url={$link}&mode=view]{$img['open']}{$link}{$img['close']}[/url]";
+						$text .= "\n[url={$link}&amp;mode=view]{$img['open']}{$link}{$img['close']}[/url]";
 					}
 				}
 

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -210,7 +210,15 @@ class main_listener implements EventSubscriberInterface
 						/* Use relative path for the sake of future's proof */
 						$link = $this->root_path . 'download/file.' . $this->php_ext . '?id=' . (int) $row['attach_id'];
 
+						/* Strip the closing XML tag as being extra content ATM */
+						$xml_close = substr($text, - 4);
+						$text = str_replace($xml_close, '', $text);
+
+						/* Add image link */
 						$text .= "\n[url={$link}&amp;mode=view]{$img['open']}{$link}{$img['close']}[/url]";
+
+						/* Add back the closing XML tag */
+						$text .= $xml_close;
 					}
 				}
 


### PR DESCRIPTION
The change to the $preg= line is just good practice to avoid using as delimiters a character that occurs in the regex string.

The real fix is to change the '&' in the reformatted link to be an html entitiy so that it does not upset the s9e renderer.

Fix #15 